### PR TITLE
Fix import statement for BinaryIO in writer.py

### DIFF
--- a/qrbarcodeitem/extlibs/barcode/writer.py
+++ b/qrbarcodeitem/extlibs/barcode/writer.py
@@ -1,7 +1,7 @@
 import gzip
 import os
 import xml.dom
-from typing.io import BinaryIO
+from typing import BinaryIO
 
 from .version import version
 


### PR DESCRIPTION
Not sure if this is still maintained, but python deprecated and removed the import from typing.io