### PR TITLE
Remove Qt6 support tag from metadata

### DIFF
--- a/qrbarcodeitem/metadata.txt
+++ b/qrbarcodeitem/metadata.txt
@@ -19,5 +19,3 @@ repository=https://github.com/gkahiu/qrbarcodeitem-plugin
 
 experimental=False
 deprecated=False
-
-supportsQt6=True


### PR DESCRIPTION
The `supportsQt6` tag is no longer necessary, see https://github.com/qgis/QGIS/pull/65168 and [the Wiki page](https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6/).